### PR TITLE
Workaround for known bug at nativeEvent function

### DIFF
--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -94,7 +94,13 @@ void CFramelessWindow::addIgnoreWidget(QWidget* widget)
 
 bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, long *result)
 {
-    MSG* msg = (MSG *)message;
+    //Workaround for known bug -> check Qt forum : https://forum.qt.io/topic/93141/qtablewidget-itemselectionchanged/13
+    #if (QT_VERSION == QT_VERSION_CHECK(5, 11, 1))
+    MSG* msg = *reinterpret_cast<MSG**>(message);
+    #else
+    MSG* msg = reinterpret_cast<MSG*>(message);
+    #endif
+    
     switch (msg->message)
     {
     case WM_NCCALCSIZE:


### PR DESCRIPTION
Thanks for this great lib! It was just what I was looking for.

Unfortunately I found a bug with QT version 5.11 and I'm here suggesting the work around with backward compatibility. 

=================================================================
Workaround for known bug at nativeEvent function, the MSG was returning the wrong uint value and therefore was always hitting the default option of the switch.
Check Qt forum : https://forum.qt.io/topic/93141/qtablewidget-itemselectionchanged/13