### PR TITLE
Fix "White bars" glitch when maximising the window (Windows 10)

### DIFF
--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -106,7 +106,7 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
     case WM_NCCALCSIZE:
     {
         //this kills the window frame and title bar we added with WS_THICKFRAME and WS_CAPTION
-        *result = 0;
+        *result = WVR_REDRAW;
         return true;
     }
     case WM_NCHITTEST:
@@ -228,10 +228,6 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
             if (m_bJustMaximized)
             {
                 QMainWindow::setContentsMargins(m_margins);
-                //after window back to normal size from maximized state
-                //a twinkle will happen, to avoid this twinkle
-                //repaint() is important used just before the window back to normal
-                repaint();
                 m_frames = QMargins();
                 m_bJustMaximized = false;
             }


### PR DESCRIPTION
On Windows 10, there is a graphical glitch that appears when maximising the frameless window.
On a single monitor setup, two white bars will appear on the top and left corner for one frame before disappearing.  On a dual-monitor setup, the bars will remain forever until you manually repaint.  

This patch fixes the graphical glitch by forcing a repaint when resizing the non-client rect (and removes the manual repaint - we don't need it!).