### PR TITLE
Fix graphical glitch on drag resize

### DIFF
--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -106,6 +106,7 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
     case WM_NCCALCSIZE:
     {
         NCCALCSIZE_PARAMS& params = *reinterpret_cast<NCCALCSIZE_PARAMS*>(msg->lParam);
+ 	if (params.rgrc[0].top != 0)
 		params.rgrc[0].top -= 1;
 
         //this kills the window frame and title bar we added with WS_THICKFRAME and WS_CAPTION

--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -105,6 +105,9 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
     {
     case WM_NCCALCSIZE:
     {
+        NCCALCSIZE_PARAMS& params = *reinterpret_cast<NCCALCSIZE_PARAMS*>(msg->lParam);
+		params.rgrc[0].top -= 1;
+
         //this kills the window frame and title bar we added with WS_THICKFRAME and WS_CAPTION
         *result = 0;
         return true;


### PR DESCRIPTION
When making the window larger, a white box will appear for a frame before the actual resize takes place.
This prevents that from occurring.

I have no idea why this works, but it looks like Qt Internally overrides WM_NCCALCSIZE and stores the original rect before calling your code.
Either way, the result is pretty.  :)